### PR TITLE
Test to skip the ci only on build to main [skip ci]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: test
         run: |
-          echo "🍓"
+          echo "🍍"
       - name: test-release
         if: github.ref == 'refs/heads/main'
         run: |


### PR DESCRIPTION
The keyword to skip the ci will be only added to the PR title.
PR build should not be skipped.